### PR TITLE
Fix/jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,17 @@
 import type { Config } from "jest";
 
 const config: Config = {
-  preset: "ts-jest", // ts-jest를 사용하여 TypeScript 파일을 변환
-  testEnvironment: "jest-environment-jsdom", // react 컴포넌트 테스트를 위한 jsdom 환경 설정
+  preset: "ts-jest",
+  testEnvironment: "jest-environment-jsdom",
+  transform: {
+    "^.+\\.(ts|tsx)$": [
+      "ts-jest",
+      {
+        tsconfig: "<rootDir>/tsconfig.jest.json", // tsconfig 파일을 여기서 지정
+      },
+    ],
+  },
+
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };
 

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,14 @@
 {
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts?(x)"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/*.test.ts?(x)"
+  ],
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "Node",
@@ -12,14 +20,18 @@
     "noImplicitAny": true,
     "strict": true,
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
     "isolatedModules": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "noEmit": true,
     "allowJs": true,
     "incremental": true,


### PR DESCRIPTION
### PR 목적

- [ ] 기능 추가 : 
- [ ] 스타일 :
- [ ] 리팩토링 :
- [ ] 문서 수정 :
- [x] 버그 수정 : Jest 테스트 환경 설정 문제 해결 및 ts-jest 분리 설정 적용
- [ ] 기타 :

### 요약

**문제 요약**

> 문제 발생 시점: Jest 테스트 실행 중
> 발생한 에러:
> SyntaxError: Unexpected token '<' (JSX 파싱 오류)
> Error: Cannot combine importAssertions and importAttributes plugins. (Babel 플러그인 충돌)


**문제의 원인** :
 Next.js와 Jest의 설정 충돌: Next.js는 TypeScript와 JSX 파일을 jsx: "preserve"로 처리하며, Babel을 통해 JSX를 변환합니다. 그러나 Jest는 JSX 변환을 제대로 처리하지 못해 SyntaxError를 발생시켰습니다.

### 전달사항
**해결 방법**
- Jest 전용 TypeScript 설정 분리 (tsconfig.jest.json 파일 추가):
Next.js에서 사용하는 tsconfig.json과는 별도로, Jest 테스트 환경에서만 사용할 tsconfig.jest.json 파일을 추가하여 Jest 전용 TypeScript 설정을 정의했습니다.
이 설정을 통해 Jest가 Next.js 설정과 충돌하지 않고 JSX 및 TypeScript 파일을 올바르게 처리할 수 있도록 했습니다

**변경 사항 요약**
- tsconfig.jest.json 추가 및 Jest 전용 TypeScript 설정 분리